### PR TITLE
Fix when resError.syscall is undefined.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -159,7 +159,7 @@ Test.prototype.assert = function(resError, res, fn) {
     ETIMEDOUT: 'Operation timed out'
   };
 
-  if (!res && resError && (resError instanceof Error) && (resError.syscall === 'connect')
+  if (!res && resError && (resError instanceof Error)
       && (Object.getOwnPropertyNames(sysErrors).indexOf(resError.code) >= 0)) {
     error = new Error(resError.code + ': ' + sysErrors[resError.code]);
     fn.call(this, error, null);


### PR DESCRIPTION
I found a case when `resError.syscall` is `undefined`, but `resError`'s code is `ECONNRESET`. So I removed it validating `resError.syscall` must be `connect`.
