### PR TITLE
fix: Fail expectations that throw non-Errors

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -308,6 +308,12 @@ function wrapAssertFn(assertFn) {
       err = assertFn(res);
     } catch (e) {
       err = e;
+
+      // Handle errors that fail `instanceof Error`, like `throw 1;` or dealing with multiple realms/contexts:
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms
+      if (!(err instanceof Error)) {
+        err = new Error(err);
+      }
     }
     if (err instanceof Error && err.stack) {
       badStack = err.stack.replace(err.message, '').split('\n').slice(1);

--- a/test/supertest.js
+++ b/test/supertest.js
@@ -871,6 +871,20 @@ describe('request(app)', function () {
           .expect('Content-Type', /text/)
           .end(done);
       });
+
+      it('fails for non-Error values that are thrown', function (done) {
+        get
+          .expect(function (res) {
+            // eslint-disable-next-line no-throw-literal
+            throw 'error123';
+          })
+          .end(function (err) {
+            should.exist(err);
+            err.message.should.equal('error123');
+            shouldIncludeStackWithThisFile(err);
+            done();
+          });
+      });
     });
 
     describe('handling multiple assertions per field', function () {


### PR DESCRIPTION
I hit a very strange error in one of my codebases (private, unfortunately, else I'd link to it). Here's a pretend example:

```ts
.expect((res) => {
  Buffer.from(undefined);
});
```

In normal environments, `Buffer.from(undefined)` throws a TypeError, which then correctly passes all `instanceof Error` checks. For reasons which I haven't fully diagnosed, but appear related to something to do with my setup (Jest? JSDom? Unsure.) and [this warning](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms), the below actually logs false: 

```ts
.expect((res) => {
  try {
    Buffer.from(undefined);
  } catch (error) {
    console.log(error instanceof Error);
  }
});
```

Now, this is a silly example, but in my test I was trying to convert a buffer to a string and assert its string result. Something like: 

```ts
.expect((res) =>
  expect(Buffer.from(res.body.data).toString('utf-8')).toBe(
    'some value',
  ),
);
```

For my example, what I actually wanted was `res.body.data.toString` (the `Buffer.from` was unnecessary), but it was throwing, *and silently failing* because of the above-described problem. 

I tried a couple things, like trying to see if something "looks like" an error, but the simplest thing I could land on was to just simply covert non-errors to errors, and then the rest of the codebase is happy. Incidentally, and I would argue this is a good thing, it also now fails if you do `throw 123`, which while not a great throw, should probably fail, and previously did not. 

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
